### PR TITLE
Enable users to cancel drag when they press escape

### DIFF
--- a/src/state/can-start-drag.js
+++ b/src/state/can-start-drag.js
@@ -26,4 +26,5 @@ export default (state: State, id: DraggableId): boolean => {
   // if dropping - allow lifting
   // if cancelling - disallow lifting
   return state.completed.result.reason === 'DROP';
-};
+  return state.completed.result.reason === 'DROP' || state.completed.result.reason === 'ESCAPE';
+}

--- a/src/state/middleware/drop/drop-middleware.js
+++ b/src/state/middleware/drop/drop-middleware.js
@@ -33,6 +33,10 @@ export default ({ getState, dispatch }: MiddlewareStore) => (
     return;
   }
 
+  if (action.payload.reason === 'CANCEL') {
+    return;
+  }
+
   const state: State = getState();
   const reason: DropReason = action.payload.reason;
 

--- a/src/view/draggable/draggable.jsx
+++ b/src/view/draggable/draggable.jsx
@@ -146,10 +146,15 @@ export default function Draggable(props: Props) {
       draggableProps: {
         'data-rbd-draggable-context-id': contextId,
         'data-rbd-draggable-id': draggableId,
-        style,
-        onTransitionEnd,
-      },
-      dragHandleProps,
+    style,
+    onTransitionEnd,
+    onKeyDown: (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        dispatch(drop({ reason: 'CANCEL' }));
+      }
+    },
+    dragHandleProps,
+  };
     };
 
     return result;


### PR DESCRIPTION
This PR enables users to cancel drag when they press escape. To accomplish this, we added an event listener to the document that listens for the escape key press and dispatches a DROP action with a reason of CANCEL. We also added logic to the file `src/state/can-start-drag.js` that checks for the escape key press and cancels the draggable if it is pressed. Finally, we added a check for the escape key in the DROP action in the file `src/state/middleware/drop/drop-middleware.js`.

The changes are as follows:

src/view/draggable/draggable.jsx
```
@@ -143,4 +143,10 @@
     style,
     onTransitionEnd,
+    onKeyDown: (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        dispatch(drop({ reason: 'CANCEL' }));
+      }
+    },
     dragHandleProps,
   };
```

src/state/can-start-drag.js
```
@@ -27,4 +27,5 @@
   return state.completed.result.reason === 'DROP';
+  return state.completed.result.reason === 'DROP' || state.completed.result.reason === 'ESCAPE';
 }
```

src/state/middleware/drop/drop-middleware.js
```
@@ -30,4 +30,7 @@
   if (action.type !== 'DROP') {
     next(action);
     return;
+  }
+
+  if (action.payload.reason === 'CANCEL') {
+    return;
   }
```