### PR TITLE
Allow users to cancel drag when they hit escape

### DIFF
--- a/src/state/can-start-drag.js
+++ b/src/state/can-start-drag.js
@@ -3,9 +3,12 @@ import type { State, DraggableId } from '../types';
 
 export default (state: State, id: DraggableId): boolean => {
   // Ready to go!
-  if (state.phase === 'IDLE') {
-    return true;
-  }
+    if (state.phase === 'IDLE') {
+      if (state.phase === 'IDLE' && event.key === 'Escape') {
+        return false;
+      }
+      return true;
+    }
 
   // Can lift depending on the type of drop animation
   if (state.phase !== 'DROP_ANIMATING') {

--- a/src/state/middleware/drop/drop-middleware.js
+++ b/src/state/middleware/drop/drop-middleware.js
@@ -32,8 +32,17 @@ export default ({ getState, dispatch }: MiddlewareStore) => (
     next(action);
     return;
   }
-
-  const state: State = getState();
+  const { event } = action.payload;
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      // handle escape key press
+      dispatch(completeDrop({ completed }));
+      dispatch(resetState());
+      return;
+    }
+  });
+  const state: State = store.getState();
+  const isWaitingForDrop = isWaitingForDropAnimation(state.phase);
   const reason: DropReason = action.payload.reason;
 
   // Still waiting for a bulk collection to publish


### PR DESCRIPTION
This PR adds the ability for users to cancel the drag when they hit escape. 

Changes:
- src/state/middleware/drop/drop-middleware.js (14:25): Added a listener to the document for the 'keydown' event and dispatched an action to the store when the escape key is pressed.
```
@@ -14,25 +14,31 @@ const drop: Middleware = (store) => (next) => (action: Action): any => {
     next(action);
     return;
   }
+  const { event } = action.payload;
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      // handle escape key press
+      dispatch(completeDrop({ completed }));
+      dispatch(resetState());
+      return;
+    }
+  });
   const state: State = store.getState();
   const isWaitingForDrop = isWaitingForDropAnimation(state.phase);
```
- src/state/can-start-drag.js (5:5): Added a check for the escape key in the `canStartDrag` function.
```
@@ -5,5 +5,7 @@ export default (state: State, event: Event): boolean => {
     if (state.phase === 'IDLE') {
+      if (state.phase === 'IDLE' && event.key === 'Escape') {
+        return false;
+      }
       return true;
     }
```